### PR TITLE
updated run script for ./dev.sh

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 
@@ -10,7 +10,11 @@ git submodule update --init --recursive
 mkdir -p /tmp/upload
 mkdir -p /tmp/workdir
 
-#docker-compose up --build
-docker-compose up
-
-
+# ok docker compose is now included in docker as an option for docker
+if [[ $(command -v docker-compose) ]]; then 
+    # if the older version is installed use the dash
+    docker-compose up
+else
+    # if the newer version is installed don't use the dash
+    docker compose up
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
 
   mongodb:
     image: mongo:4.4.15
+    platform: linux/amd64
     volumes: 
       - /data/db
     healthcheck:
@@ -16,6 +17,7 @@ services:
 
   api:
     build: .
+    platform: linux/amd64
     volumes:
       - ./api:/app/api
       - /tmp:/tmp
@@ -31,6 +33,7 @@ services:
 
   handler:
     build: ./handler
+    platform: linux/amd64
     volumes:
       - .:/app
       - /tmp:/tmp
@@ -43,6 +46,7 @@ services:
 
   ui:
     build: ./ui
+    platform: linux/amd64
     volumes:
       - ./ui/src:/ui/src #don't copy node_modules which might be compiled for mac (vite won't work)
     environment:

--- a/handler/Dockerfile
+++ b/handler/Dockerfile
@@ -1,79 +1,65 @@
 FROM neurodebian:nd20.04-non-free
 
+SHELL ["/bin/bash", "-c"]
+
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt update
 
-RUN apt install -y parallel python3 python3-pip tree curl unzip git jq
+RUN apt update && \
+    apt-get update && apt-get upgrade -y
 
-RUN apt-get update && apt-get upgrade -y && \
-    apt-get install -y build-essential pkg-config cmake git pigz && \
+RUN apt install -y parallel python3 python3-pip tree curl unzip git jq python libgl-dev python-numpy
+RUN pip3 install numpy nibabel pandas==1.0.1 matplotlib pyyaml==5.4.1 natsort pydeface && \
+    pip3 install quickshear
+
+RUN apt-get install -y build-essential pkg-config cmake git pigz rename zstd libopenjp2-7 wget && \
     apt-get clean -y && apt-get autoclean -y && apt-get autoremove -y
 
-#install fsl6
-##https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FslInstallation/Linux
-RUN apt update && apt install -y wget python libgl-dev jq python-numpy
-
-#install fsl, but get rid of src
+#this is the most tedious that's why it's one of the first layers installed
+#install fsl, and get rid of src
 RUN wget https://fsl.fmrib.ox.ac.uk/fsldownloads/fslinstaller.py && \
-      python fslinstaller.py -d /usr/local/fsl -V 6.0.4 && rm -rf /usr/local/fsl/src
+      python fslinstaller.py -d /usr/local/fsl -V 6.0.6 && rm -rf /usr/local/fsl/src
 
 ENV FSLDIR=/usr/local/fsl
 ENV PATH=$PATH:$FSLDIR/bin
 ENV LD_LIBRARY_PATH=$FSLDIR/lib
-
 RUN . $FSLDIR/etc/fslconf/fsl.sh
 
 ENV FSLOUTPUTTYPE=NIFTI_GZ
 
 #make sure fslpython is properly installed
-#RUN which imcp
+RUN which imcp
 
-RUN apt install -y curl
-RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
-RUN apt install -y nodejs
+# certs have expired for nodesource use the hack below to get around that for install
+#### HACK Warning ####
+# unfortuanetly this seems to work the most reliably
+# see https://github.com/nodesource/distributions/issues/1266#issuecomment-938408547 and
+RUN echo "insecure" > $HOME/.curlrc \
+    && echo "Acquire::https::Verify-Peer false;" >> /etc/apt/apt.conf.d/80ssl-exceptions \ 
+    && echo "Acquire::https::Verify-Host false;" >> /etc/apt/apt.conf.d/80ssl-exceptions \
+    && curl -fsSL https://deb.nodesource.com/setup_14.x | bash - \
+    && apt install -y nodejs \ 
+    && rm -f $HOME/.curlrc \
+    && rm -f /etc/apt/apt.conf.d/80ssl-exceptions \
+    && npm --version
 
-# Get dcm2niix from github and compile
-#RUN cd /tmp && \
-#    git clone https://github.com/rordenlab/dcm2niix.git -b v1.0.20211006 && \
-#    cd dcm2niix && mkdir build && cd build && \
-#    cmake -DBATCH_VERSION=ON -DUSE_OPENJPEG=ON .. && \
-#    make && make install
-
-#RUN wget https://github.com/rordenlab/dcm2niix/releases/download/v1.0.20211006/dcm2niix_lnx.zip -O /tmp/dcm2niix_lnx.zip
-
-RUN apt-get install -y libopenjp2-7
-RUN wget https://github.com/rordenlab/dcm2niix/releases/download/v1.0.20220720/dcm2niix_lnx.zip -O /tmp/dcm2niix_lnx.zip
-
-RUN unzip /tmp/dcm2niix_lnx.zip
-RUN mv dcm2niix /usr/local/bin
+RUN wget https://github.com/rordenlab/dcm2niix/releases/download/v1.0.20220720/dcm2niix_lnx.zip -O /tmp/dcm2niix_lnx.zip && \
+    unzip /tmp/dcm2niix_lnx.zip && \
+    mv dcm2niix /usr/local/bin
 
 # Get bids-specification from github
 RUN cd && git clone https://github.com/bids-standard/bids-specification
 
-#tensorflow2 needs pip>19
-#RUN pip3 install --upgrade pip
-
-RUN pip3 install numpy nibabel pandas==1.0.1 matplotlib pyyaml==5.4.1 natsort #need it before I can install quickshear
-RUN pip3 install quickshear
-
 #install ROBEX
-#COPY ROBEXv12.linux64.tar.gz /
 ADD https://www.nitrc.org/frs/download.php/5994/ROBEXv12.linux64.tar.gz//?i_agree=1&download_now=1 /
-RUN ls -la
 RUN tar -xzf /ROBEXv12.linux64.tar.gz
-ENV PATH=$PATH:/ROBEX
+ENV PATH /ROBEX:$PATH
 
-#install pydeface
-RUN pip3 install pydeface
-
-RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 #install bids-validator
 RUN npm install -g bids-validator@1.9.6
 
-RUN apt-get install -y rename zstd
-
+# install source code from local
 WORKDIR /app/handler
-RUN npm install -g pm2 #for dev
-
-
+RUN npm -g install pm2


### PR DESCRIPTION
Had some issues with getting dev.sh to behave, mostly w/ node source.

- updated docker-compose to use --platform linux/amd64 to play nicer w/ m1 mac
- updated handler/Dockerfile to fewer layers and fixed issue w/ node install
- added logic to use docker compose if docker-compose not found when executing ./dev.sh

I'm not super happy about the certificate hack to the `handler/Dockerfile`, but it's the only consistent way that I managed to get things working

Still running into issues w/ some things not mounting/loading, but it does compose and one can reach EZbids at localhost:3000. Will touch things up if you want to wait on this.
