### PR TITLE
[ENH] Add additional MEG support

### DIFF
--- a/handler/convert_meg.py
+++ b/handler/convert_meg.py
@@ -3,10 +3,20 @@
 """
 Takes the ezBIDS data (finalized.json) and uses MNE-BIDS to perform the BIDS conversion for this
 specific modality data.
+
+Regarding emptyroom recordings and their BIDS specification, there are 4 scenarios:
+1). One noise recording per subject (one subject in day)
+2). One noise recording per day (multiple subjects in day)
+3). One or very few noise recordings per full dataset
+4). No noise recordings in entire dataset
+
+Given the difficulty in determing the various ways imaging data may match with emptyroom data, will have a separate
+sub-emptyroom folder. This will makes things simplier.
 """
 
 import sys
 import json
+from datetime import datetime
 from mne.io import read_raw
 from mne_bids import (BIDSPath, write_raw_bids)
 
@@ -14,17 +24,17 @@ from mne_bids import (BIDSPath, write_raw_bids)
 finalized_json_data = json.load(open(sys.argv[1]), strict=False)
 bids_root_dir = sys.argv[2]
 
-# subjects = finalized_json_data["subjects"]  # Is this the final say?
-subjects = [x["_entities"]["subject"] for x in finalized_json_data["objects"]]
+sub_info = finalized_json_data["subjects"]
+subjects = [x["subject"] for x in sub_info]
 
-# Let's see how many MEG objects there are
-for obj in finalized_json_data["objects"]:
+# See how many MEG objects there are
+objects = finalized_json_data["objects"]
+for obj in objects:
     obj_type = obj["_type"]
     if "meg" in obj_type:
         datatype = "meg"
-        img_data = obj["_SeriesDescription"]
 
-        raw = read_raw(img_data, verbose=0)
+        raw = read_raw(obj["_SeriesDescription"], verbose=0)
 
         # Get entity information
         entities = obj["_entities"]
@@ -32,11 +42,15 @@ for obj in finalized_json_data["objects"]:
         ses_idx = obj["session_idx"]
 
         # sub
-        sub = subjects[sub_idx]["subject"]
+        sub = sub_info[sub_idx]["subject"]
 
         # ses
-        ses = subjects[sub_idx]["sessions"][ses_idx]
-        if ses["session"] == "" or ses["exclude"] is True:
+        ses_info = sub_info[sub_idx]["sessions"][ses_idx]
+        if ses_info["session"] != "":
+            ses = ses_info["session"]
+            if ses_info["exclude"] is True:
+                ses = None
+        else:
             ses = None
 
         # task
@@ -66,28 +80,86 @@ for obj in finalized_json_data["objects"]:
         else:
             split = entities["split"]
 
-        # Create an MNE BIDSpath
-        bids_path = BIDSPath(
-            subject=sub,
-            session=ses,
-            task=task,
-            acquisition=acq,
-            run=run,
-            processing=proc,
-            split=split,
-            datatype=datatype,
-            root=bids_root_dir
-        )
+        # Set up BIDS configuration (for MEG data only)
+        if sub == "emptyroom":
+            raw_er = raw
+            # Specify the BIDS path for emptyroom (ER) recording
+            bids_path_er = BIDSPath(
+                subject=sub,
+                session=ses,
+                task="noise",
+                acquisition=acq,
+                run=run,
+                processing=proc,
+                split=split,
+                datatype=datatype,
+                root=bids_root_dir
+            )
 
-        print("Converting MEG data to BIDS")
-        empty_room = None
-        if "emptyroom" in subjects and sub != "emptyroom":
-            er_idx = subjects.index("emptyroom")
-            raw_er_data = finalized_json_data["objects"][er_idx]["SeriesDescription"]
-            raw_er = read_raw(raw_er_data, verbose=0)
-            empty_room = raw_er
+            # Write ER data to BIDS structure
+            write_raw_bids(raw_er, bids_path=bids_path_er, overwrite=True)
+        else:
+            raw_data = raw
+            # Specify the BIDS path for imaging data
+            bids_path_data = BIDSPath(
+                subject=sub,
+                session=ses,
+                task=task,
+                acquisition=acq,
+                run=run,
+                processing=proc,
+                split=split,
+                datatype=datatype,
+                root=bids_root_dir
+            )
 
-        write_raw_bids(raw, bids_path=bids_path, verbose=0, empty_room=empty_room, overwrite=True)
+            raw_data_dt = [
+                int(x) for x in obj["AcquisitionDate"].split("-") + obj["AcquisitionTime"].split(":")[:-1]
+            ]
+            raw_data_datetime = datetime(
+                raw_data_dt[0],
+                raw_data_dt[1],
+                raw_data_dt[2],
+                raw_data_dt[3],
+                raw_data_dt[4]
+            )
+
+            # Does ER data exist?
+            num_er = [x for x in subjects if x == "emptyroom"]
+            er_datetimes = []
+            if len(num_er):
+                """
+                Determine which ER datetime recording is closest (and before) the imaging data. For reference, see
+                https://www.geeksforgeeks.org/python-find-the-closest-date-from-a-list/#
+                """
+                er_sub_idxs = [idx for idx, value in enumerate(subjects) if value == "emptyroom"]
+                er_objs = [x for x in objects if x["subject_idx"] in er_sub_idxs]
+                er_objs_acq_datetimes = [
+                    x["AcquisitionDate"].split("-") + x["AcquisitionTime"].split(":")[:-1] for x in er_objs
+                ]
+
+                for i in er_objs_acq_datetimes:
+                    er_datetimes.append(datetime(int(i[0]), int(i[1]), int(i[2]), int(i[3]), int(i[4])))
+
+                # get all differences with date as values
+                clos_dict = {abs(raw_data_datetime.timestamp() - date.timestamp()): date for date in er_datetimes}
+
+                # extracting minimum key using min()
+                res = clos_dict[min(clos_dict.keys())]
+
+                corr_er = [
+                    x for x in er_objs if x["AcquisitionDate"] == res.strftime("%Y-%m-%d")
+                    and res.strftime("%H:%M") in x["AcquisitionTime"]
+                ][0]  # Should only be length of 1
+
+                raw_er = read_raw(corr_er["_SeriesDescription"], verbose=0)
+
+                # Write MEG data to BIDS structure (with corresponding ER)
+                write_raw_bids(raw_data, bids_path=bids_path_data, empty_room=raw_er, overwrite=True)
+
+            else:
+                # Write MEG data to BIDS structure (no corresponding ER)
+                write_raw_bids(raw_data, bids_path=bids_path_data, overwrite=True)
 
 print("Finished MEG BIDS conversion (with MNE-BIDS)")
 print("")

--- a/handler/convert_meg.py
+++ b/handler/convert_meg.py
@@ -10,8 +10,8 @@ Regarding emptyroom recordings and their BIDS specification, there are 4 scenari
 3). One or very few noise recordings per full dataset
 4). No noise recordings in entire dataset
 
-Given the difficulty in determing the various ways imaging data may match with emptyroom data, will have a separate
-sub-emptyroom folder. This will makes things simplier.
+Given the difficulty in determining the various ways imaging data may match with emptyroom data, will have a separate
+sub-emptyroom folder. This will makes things simpler for now.
 """
 
 import sys

--- a/handler/ezBIDS_core/createThumbnailsMovies.py
+++ b/handler/ezBIDS_core/createThumbnailsMovies.py
@@ -23,10 +23,8 @@ plt.style.use('dark_background')
 
 os.environ['MPLCONFIGDIR'] = os.getcwd() + "/configs/"
 
-DATA_DIR = sys.argv[1]
-
-
 # Functions
+
 
 def create_MEG_thumbnail():
     """
@@ -35,8 +33,6 @@ def create_MEG_thumbnail():
     import mne.viz
 
     uploaded_json_list = natsorted(pd.read_csv("list", header=None, lineterminator='\n').to_numpy().flatten().tolist())
-
-    MEG_extensions = [".ds", ".fif", ".sqd", ".con", ".raw", ".ave", ".mrk", ".kdf", ".mhd", ".trg", ".chn", ".dat"]
 
     """
     Get the MEG data organized
@@ -49,7 +45,7 @@ def create_MEG_thumbnail():
 
     if len(MEG_data_files):
         for meg in MEG_data_files:
-            fname = f"{DATA_DIR}/{meg}"
+            fname = f"{data_dir}/{meg}"
             raw = mne.io.read_raw(fname, verbose=0)
             mne.viz.set_browser_backend('matplotlib', verbose=None)
 
@@ -163,19 +159,15 @@ def create_DWIshell_thumbnails(nifti_file, image, bval_file):
 # Begin:
 data_dir = sys.argv[1]
 json_file = sys.argv[2]
+MEG_extensions = [".ds", ".fif", ".sqd", ".con", ".raw", ".ave", ".mrk", ".kdf", ".mhd", ".trg", ".chn", ".dat"]
 os.chdir(data_dir)
 
-json_list = pd.read_csv("list", header=None, lineterminator="\n").to_numpy().flatten().tolist()
-
 nifti_file = json_file.split(".json")[0] + ".nii.gz"
-print("")
-print(nifti_file)
-print("")
 
 create_MEG_thumbnail()
 
-if not os.path.isfile(f"{data_dir}/{nifti_file}"):  # no corresponding nifti, so don't process
-    print(f"{json_file} does not have a corresponding NIfTI file, cannot process")
+if not os.path.isfile(f"{data_dir}/{nifti_file}"):
+    print(f"{json_file} does not have a corresponding NIfTI file, cannot generate screenshot")
 else:
     output_dir = nifti_file.split(".nii.gz")[0]
     image = nib.load(nifti_file)

--- a/handler/ezBIDS_core/update_ezBIDS_core.py
+++ b/handler/ezBIDS_core/update_ezBIDS_core.py
@@ -27,7 +27,7 @@ with open("ezBIDS_core.json", "r") as ezBIDS_json:
     ezBIDS = json.load(ezBIDS_json)
 
 for json_file in json_list:
-    if any(x in json_file for x in MEG_extensions):
+    if json_file.endswith(tuple(MEG_extensions)):
         nifti_file = json_file
     else:
         nifti_file = json_file.split(".json")[0] + ".nii.gz"
@@ -36,6 +36,7 @@ for json_file in json_list:
         for obj in ezBIDS["objects"]:
             for item in obj["items"]:
                 path = item["path"]
+
                 if path == nifti_file:
                     files = [
                         os.path.join(os.path.dirname(nifti_file), x) for x in os.listdir(os.path.dirname(nifti_file))

--- a/handler/preprocess.sh
+++ b/handler/preprocess.sh
@@ -234,7 +234,6 @@ else
     echo "running ezBIDS_core (may take several minutes, depending on size of data)"
     python3 "./ezBIDS_core/ezBIDS_core.py" $root
 
-
     echo "generating thumbnails for 3/4D acquisitions (may take several minutes, depending on size of dataset)"
     cat $root/list | parallel --linebuffer -j 6 --progress python3 "./ezBIDS_core/createThumbnailsMovies.py" $root
 

--- a/ui/src/Objects.vue
+++ b/ui/src/Objects.vue
@@ -310,7 +310,7 @@
                         <el-form-item v-if="item.sidecar" label="sidecar">
                             <el-input v-model="item.sidecar_json" type="textarea" rows="10" @blur="update(so)" />
                         </el-form-item>
-                        <el-form-item v-if="item.headers" label="Nifti Headers (readonly)">
+                        <el-form-item v-if="item.headers" label="Nifti Headers (read-only)">
                             <pre class="headers">{{ item.headers }}</pre>
                         </el-form-item>
                         <el-form-item v-if="item.eventsBIDS" label="eventsBIDS">

--- a/ui/src/components/showfile.vue
+++ b/ui/src/components/showfile.vue
@@ -42,6 +42,8 @@ export default defineComponent({
                 );
             })
             .then((res) => {
+                const text = JSON.stringify(res.data, undefined, 4);
+                this.content = convert.toHtml(text);
                 // data from the BE will have newlines which informs indentation in the frontend
                 this.content = convert.toHtml(res.data);
             })


### PR DESCRIPTION
This PR builds on #106 

Additional MEG support is added, primarily regarding emptyroom recordings. 

Per the MEG BIDS specification, there are [two ways](https://bids-specification.readthedocs.io/en/latest/modality-specific-files/magnetoencephalography.html#empty-room-meg-recordings) for storing emptyroom recordings. This PR defaults to the Example 1 approach, simply due to easier use. 