### PR TITLE
[ENH] Redeploy PET support with --skim option

### DIFF
--- a/handler/Dockerfile
+++ b/handler/Dockerfile
@@ -10,7 +10,7 @@ RUN apt update && \
 RUN apt install -y parallel python3 python3-pip tree curl unzip git jq python libgl-dev python-numpy
 
 RUN pip3 install numpy==1.23.0 nibabel==4.0.0 pandas==1.0.1 matplotlib pyyaml==5.4.1 pydicom==2.3.1 natsort pydeface && \
-    pip3 install quickshear pypet2bids==1.3.5 mne mne-bids
+    pip3 install quickshear pypet2bids==1.3.9 mne mne-bids
 
 RUN apt-get install -y build-essential pkg-config cmake git pigz rename zstd libopenjp2-7 libgdcm-tools wget libopenblas-dev && \
     apt-get clean -y && apt-get autoclean -y && apt-get autoremove -y

--- a/handler/find_img_data.py
+++ b/handler/find_img_data.py
@@ -62,27 +62,26 @@ meg_data_list = []
 
 find_img_data('.')
 
-# # PET
-# # TODO - Line below line take several seconds to complete, maybe can be sped up?
-# pet_folders = [str(folder) for folder in is_pet.pet_folder(Path(root).resolve())]
-# pet_folders = [os.path.relpath(x, root) for x in pet_folders if x != '']
-# pet_folders = [os.path.join('.', x) for x in pet_folders]
+# PET
+pet_folders = [str(folder) for folder in is_pet.pet_folder(Path(root).resolve(), skim=True, njobs=4)]
+pet_folders = [os.path.relpath(x, root) for x in pet_folders if x != '']
+pet_folders = [os.path.join('.', x) for x in pet_folders]
 
-# if pet_folders:
-#     for pet in pet_folders:
-#         # See if we're dealing ECAT-formatted file(s)
-#         ecats = [x for x in os.listdir(pet) if x.endswith(tuple(['.v', '.v.gz']))]
-#         if len(ecats):
-#             for ecat in ecats:
-#                 if ecat not in pet_ecat_files_list:
-#                     pet_ecat_files_list.append(f'{pet}/{ecat}')
-#         # See if we're dealing with DICOM files
-#         dcms = [
-#             x for x in os.listdir(pet)
-#             if not x.endswith(tuple(['.nii', '.nii.gz', '.v', '.v.gz', '.json', '.tsv']))
-#         ]
-#         if len(dcms) and pet not in pet_dcm_dirs_list:
-#             pet_dcm_dirs_list.append(pet)
+if pet_folders:
+    for pet in pet_folders:
+        # See if we're dealing ECAT-formatted file(s)
+        ecats = [x for x in os.listdir(pet) if x.endswith(tuple(['.v', '.v.gz']))]
+        if len(ecats):
+            for ecat in ecats:
+                if ecat not in pet_ecat_files_list:
+                    pet_ecat_files_list.append(f'{pet}/{ecat}')
+        # See if we're dealing with DICOM files
+        dcms = [
+            x for x in os.listdir(pet)
+            if not x.endswith(tuple(['.nii', '.nii.gz', '.v', '.v.gz', '.json', '.tsv']))
+        ]
+        if len(dcms) and pet not in pet_dcm_dirs_list:
+            pet_dcm_dirs_list.append(pet)
 
 # MEG
 MEG_extensions = ['*.ds', '*.fif', '*.sqd', '*.con', '*.raw', '*.ave', '*.mrk', '*.kdf', '*.mhd', '*.trg', '*.chn', '*.dat']


### PR DESCRIPTION
Before, pet2bids needed to check each file to assess whether the files were PET or not `is_pet`. This PR updates the pet2bids version, which includes a `--skim` option to speed up this process, as it creates a bottleneck in the ezBIDS workflow, specifially, at `find_img_data.py`