### PR TITLE
[BUG] Fixes "Transpile to JS Error" in API container; revert node version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
             "devDependencies": {
                 "@types/async": "^3.2.12",
                 "@types/cors": "^2.8.12",
-                "@types/node": "^16.11.26",
+                "@types/node": "^20",
                 "@typescript-eslint/eslint-plugin": "^6.9.1",
                 "@typescript-eslint/parser": "^6.9.1",
                 "eslint": "^8.52.0",
@@ -1495,9 +1495,12 @@
             "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
         },
         "node_modules/@types/node": {
-            "version": "16.18.43",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.43.tgz",
-            "integrity": "sha512-YFpgPKPRcwYbeNOimfu70B+TVJe6tr88WiW/TzEldkwGxQXrmabpU+lDjrFlNqdqIi3ON0o69EQBW62VH4MIxw=="
+            "version": "20.14.13",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.13.tgz",
+            "integrity": "sha512-+bHoGiZb8UiQ0+WEtmph2IWQCjIqg8MDZMAV+ppRRhUZnquF5mQkP/9vpSwJClEiSM/C7fZZExPzfU0vJTyp8w==",
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
         },
         "node_modules/@types/qs": {
             "version": "6.9.7",
@@ -5801,6 +5804,11 @@
                 "node": ">=4.2.0"
             }
         },
+        "node_modules/undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+        },
         "node_modules/unpipe": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -7221,9 +7229,12 @@
             "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
         },
         "@types/node": {
-            "version": "16.18.43",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.43.tgz",
-            "integrity": "sha512-YFpgPKPRcwYbeNOimfu70B+TVJe6tr88WiW/TzEldkwGxQXrmabpU+lDjrFlNqdqIi3ON0o69EQBW62VH4MIxw=="
+            "version": "20.14.13",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.13.tgz",
+            "integrity": "sha512-+bHoGiZb8UiQ0+WEtmph2IWQCjIqg8MDZMAV+ppRRhUZnquF5mQkP/9vpSwJClEiSM/C7fZZExPzfU0vJTyp8w==",
+            "requires": {
+                "undici-types": "~5.26.4"
+            }
         },
         "@types/qs": {
             "version": "6.9.7",
@@ -10338,6 +10349,11 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
             "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true
+        },
+        "undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
         },
         "unpipe": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "devDependencies": {
         "@types/async": "^3.2.12",
         "@types/cors": "^2.8.12",
-        "@types/node": "^16.11.26",
+        "@types/node": "^20",
         "@typescript-eslint/eslint-plugin": "^6.9.1",
         "@typescript-eslint/parser": "^6.9.1",
         "eslint": "^8.52.0",


### PR DESCRIPTION
Fixes issue observed when running `docker compose build && docker compose up`:

```bash
brainlife_ezbids-api   | ../node_modules/@types/node/globals.d.ts(73,13): error TS2403: Subsequent variable declarations must have the same type. Variable ‘AbortSignal’ must be of type ‘{ new (): AbortSignal; prototype: AbortSignal; abort(reason?: any): AbortSignal; any(signals: AbortSignal[]): AbortSignal; timeout(milliseconds: number): AbortSignal; }‘, but here has type ‘{ new (): AbortSignal; prototype: AbortSignal; abort(reason?: any): AbortSignal; timeout(milliseconds: number): AbortSignal; }‘.
brainlife_ezbids-api   |
brainlife_ezbids-api   |
brainlife_ezbids-api   | 6:35:08 PM - Found 1 error. Watching for file changes.
brainlife_ezbids-api   | URGENT: TRANSPILE TO JAVASCRIPT FAILED! & exit 5
```

This seems to have arisen following a change in node version from `^20` to ~`16`, this PR fixes that.