### PR TITLE
Update package versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM node:16
+FROM node:20
 
 COPY . /app
 
 WORKDIR /app
-RUN npm install -g pm2 typescript tsc-watch
 
-RUN npm install
+RUN npm install -g npm@9.5.1
+
+RUN npm install -g pm2 typescript tsc-watch

--- a/dev.sh
+++ b/dev.sh
@@ -17,8 +17,8 @@ export BRAINLIFE_AUTHENTICATION
 
 git submodule update --init --recursive
 
-(cd api && npm install)
-(cd ui && npm install)
+(cd api && npm install -g npm@9.5.1)
+(cd ui && npm install -g npm@9.5.1)
 
 mkdir -p /tmp/upload
 mkdir -p /tmp/workdir

--- a/handler/Dockerfile
+++ b/handler/Dockerfile
@@ -62,7 +62,7 @@ RUN apt-get update \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 
-ARG NODE_MAJOR=16
+ARG NODE_MAJOR=20
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 
 RUN apt-get update \
@@ -90,7 +90,8 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 #install bids-validator
-RUN npm install -g bids-validator@1.11.0
+RUN npm install -g npm@9.5.1
+RUN npm install -g bids-validator@1.14.8
 RUN git clone https://github.com/bids-standard/bids-validator
 
 # install source code from local

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,8 +1,8 @@
-FROM node:16
+FROM node:20
 
 COPY . /ui
 WORKDIR /ui
 
-RUN npm install
+RUN npm install -g npm@9.5.1
 
 CMD [ "npm", "run", "dev" ]


### PR DESCRIPTION
This PR updates the bids-validator to version `1.14.8`. This required updating node and npm versions to accommodate.