### PR TITLE
Surgical audit fixes: path traversal, header leak, and latent bugs

### DIFF
--- a/api/controllers.ts
+++ b/api/controllers.ts
@@ -101,7 +101,6 @@ router.get('/health', (req, res) => {
  */
 router.post('/session', validateWithJWTConfig(), (req: Request, res: express.Response, next) => {
     req.body.status = 'created';
-    req.body.request_headers = req.headers;
 
     const session = new models.Session({
         ...req.body,
@@ -220,9 +219,6 @@ router.patch(
  *         status_msg:
  *           type: string
  *           description: Status message for the session
- *         request_headers:
- *           type: object
- *           description: Headers of the request when creating the session
  *         upload_finish_date:
  *           type: string
  *           format: date-time
@@ -547,7 +543,7 @@ router.post(
                 const destPath = path.resolve(dirtyPath);
                 const mtime = mtimes[idx] / 1000; //browser uses msec.. filesystem uses sec since epoch
 
-                if (!destPath.startsWith(config.workdir)) {
+                if (path.relative(`${config.workdir}/${session._id}`, destPath).startsWith('..')) {
                     return nextFile(new Error(`invalid path: ${destPath}`));
                 }
                 const destdir = path.dirname(destPath);

--- a/api/models.ts
+++ b/api/models.ts
@@ -48,7 +48,6 @@ export interface ISession {
     ownerId: number;
     allowedUsers: number[];
 
-    request_headers: any;
     upload_finish_date: Date;
 
     pre_begin_date: Date;
@@ -74,8 +73,6 @@ const sessionSchema = new Schema<ISession>({
 
     ownerId: Schema.Types.Number,
     allowedUsers: [Schema.Types.Number],
-
-    request_headers: Schema.Types.Mixed,
 
     upload_finish_date: Date, //when all files are uploaded
 

--- a/handler/Dockerfile
+++ b/handler/Dockerfile
@@ -10,15 +10,10 @@ RUN apt update && \
 RUN apt install -y parallel python3 python3-pip tree curl unzip git jq python libgl-dev python-numpy bc
 
 RUN pip3 install numpy==1.23.0 nibabel==4.0.0 pandas matplotlib pyyaml==5.4.1 pydicom==2.3.1 natsort pydeface && \
-    pip3 install quickshear mne mne-bids
-
-# Install pypet2bids
-RUN git clone https://github.com/openneuropet/PET2BIDS && \
-    cd PET2BIDS && make installpoetry buildpackage installpackage
+    pip3 install quickshear pypet2bids==1.3.9 mne mne-bids
 
 RUN apt-get install -y build-essential pkg-config cmake git pigz rename zstd libopenjp2-7 libgdcm-tools wget libopenblas-dev && \
     apt-get clean -y && apt-get autoclean -y && apt-get autoremove -y
-
 
 RUN touch /.pet2bidsconfig && chown 1001:1001 /.pet2bidsconfig
 RUN echo "DEFAULT_METADATA_JSON=/usr/local/lib/python3.8/dist-packages/pypet2bids/template_json.json" > /.pet2bidsconfig

--- a/handler/convert.js
+++ b/handler/convert.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 "use strict";
 const fs = require('fs');
+const path = require('path');
 const mkdirp = require('mkdirp');
 const async = require('async');
 const bidsEntitiesOrdered = require('../ui/src/assets/schema/rules/entities.json');
@@ -19,8 +20,9 @@ Object.values(bidsEntitiesOrdered).forEach(order => {
     });
 });
 info.entityMappings = newEntityOrdering;
-const datasetName = info.datasetDescription.Name;
-
+//strip path separators from the user-supplied dataset name so it cannot escape root/bids
+const datasetName = path.basename(String(info.datasetDescription.Name || "")).replace(/^\.+/, "") || "dataset";
+info.datasetDescription.Name = datasetName;
 mkdirp.sync(root + "/bids/" + datasetName);
 fs.writeFileSync(root + "/bids/" + datasetName + "/finalized.json", JSON.stringify(info, null, 4)); //copy the finalized.json
 fs.writeFileSync(root + "/bids/" + datasetName + "/dataset_description.json", JSON.stringify(info.datasetDescription, null, 4));

--- a/handler/convert.ts
+++ b/handler/convert.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const fs = require('fs');
+const path = require('path');
 const mkdirp = require('mkdirp');
 const async = require('async');
 const bidsEntitiesOrdered = require('../ui/src/assets/schema/rules/entities.json')
@@ -23,7 +24,9 @@ Object.values(bidsEntitiesOrdered).forEach(order=>{
 })
 info.entityMappings = newEntityOrdering
 
-const datasetName = info.datasetDescription.Name;
+//strip path separators from the user-supplied dataset name so it cannot escape root/bids
+const datasetName = path.basename(String(info.datasetDescription.Name || "")).replace(/^\.+/, "") || "dataset";
+info.datasetDescription.Name = datasetName;
 
 mkdirp.sync(root+"/bids/"+datasetName);
 fs.writeFileSync(root+"/bids/"+datasetName+"/finalized.json", JSON.stringify(info, null, 4)); //copy the finalized.json

--- a/handler/expand.sh
+++ b/handler/expand.sh
@@ -83,8 +83,8 @@ function expand {
     done
 
     for zst in $(find $root -name "*.zst"); do
-        zst -d $zip
-        rm -rf $zip
+        zstd -d $zst
+        rm -rf $zst
     done
 }
 

--- a/handler/ezBIDS_core/ezBIDS_core.py
+++ b/handler/ezBIDS_core/ezBIDS_core.py
@@ -985,7 +985,7 @@ def generate_dataset_list(uploaded_files_list, exclude_data):
         except:
             ornt = None
 
-        if pe_direction is not None and ornt is not None and json_data["Modality"] != "MEG":
+        if pe_direction is not None and ornt is not None and modality != "MEG":
             correction = False
             proper_pe_direction, correction = correct_pe(pe_direction, ornt, correction)
             if correction is True:

--- a/handler/find_img_data.py
+++ b/handler/find_img_data.py
@@ -61,7 +61,7 @@ pet_ecat_files_list = []
 pet_dcm_dirs_list = []
 meg_data_list = []
 
-find_img_data(root)
+find_img_data('.')
 
 # PET
 pet_folders = [str(folder) for folder in is_pet.pet_folder(Path(root).resolve(), skim=True, njobs=4)]

--- a/handler/find_img_data.py
+++ b/handler/find_img_data.py
@@ -14,10 +14,11 @@ except (ImportError, ModuleNotFoundError):
     print('pet2bids is not installed, using dcm2niix on PET directories instead')
     sys.exit(1)
 
-
 def find_img_data(dir):
     '''
     Finds all directories that contain DICOM (or other) raw imaging data.
+    Note: dcm2niix recursively searches the given directory and all subdirectories for DICOM data so this function
+    only needs to find the top-level directory of the first instance of MRI data.
     If dcm2niix output (NIfTI, JSON files) uploaded instead, ezBIDS has separate process for detecting those files.
 
     Parameters
@@ -41,7 +42,7 @@ def find_img_data(dir):
                         break
                 except:
                     # Doesn't appear to be DICOM data, so skip
-                    break
+                    pass
 
     # Complete search
     if not hasImgData:
@@ -60,7 +61,7 @@ pet_ecat_files_list = []
 pet_dcm_dirs_list = []
 meg_data_list = []
 
-find_img_data('.')
+find_img_data(root)
 
 # PET
 pet_folders = [str(folder) for folder in is_pet.pet_folder(Path(root).resolve(), skim=True, njobs=4)]

--- a/handler/handler.js
+++ b/handler/handler.js
@@ -54,7 +54,6 @@ function handle_uploaded(session) {
     return __awaiter(this, void 0, void 0, function* () {
         let workdir = config.workdir + "/" + session._id;
         session.pre_begin_date = new Date();
-        session.pre_end_date = undefined;
         session.status = "preprocessing";
         yield handle(session, "./preprocess.sh", "preprocess", cb => {
             //monitoring callback
@@ -101,7 +100,7 @@ function handle_finalized(session) {
     return __awaiter(this, void 0, void 0, function* () {
         console.log("handling finalized request!-----------------------");
         session.finalize_begin_date = new Date();
-        session.finalize_end_date = undefined;
+        session.finalize_finish_date = undefined;
         session.status = "bidsing";
         yield handle(session, "./bids.sh", "bids", cb => {
             //monitor cb
@@ -117,7 +116,7 @@ function handle_deface(session) {
     return __awaiter(this, void 0, void 0, function* () {
         console.log("handling deface request!-----------------------");
         session.deface_begin_date = new Date();
-        session.deface_end_date = undefined;
+        session.deface_finish_date = undefined;
         session.status = "defacing";
         yield handle(session, "./deface.sh", "deface", cb => {
             //monitor cb - nothing special to do yet

--- a/handler/handler.ts
+++ b/handler/handler.ts
@@ -48,9 +48,8 @@ async function handle_uploaded(session) {
     let workdir = config.workdir+"/"+session._id;
 
     session.pre_begin_date = new Date();
-    session.pre_end_date = undefined;
 
-    session.status = "preprocessing"; 
+    session.status = "preprocessing";
     await handle(session, "./preprocess.sh", "preprocess", cb=>{
         //monitoring callback
         console.log("checking dcm2niix progress--------------------------");
@@ -95,7 +94,7 @@ async function handle_finalized(session) {
     console.log("handling finalized request!-----------------------");
 
     session.finalize_begin_date = new Date();
-    session.finalize_end_date = undefined;
+    session.finalize_finish_date = undefined;
     session.status = "bidsing";
 
     await handle(session, "./bids.sh", "bids", cb=>{
@@ -112,7 +111,7 @@ async function handle_deface(session) {
     console.log("handling deface request!-----------------------");
 
     session.deface_begin_date = new Date();
-    session.deface_end_date = undefined;
+    session.deface_finish_date = undefined;
     session.status = "defacing";
 
     await handle(session, "./deface.sh", "deface", cb=>{

--- a/handler/preprocess.sh
+++ b/handler/preprocess.sh
@@ -54,11 +54,10 @@ else
     test_root=$root
 fi
 
-if [ -f $test_root/.bidsignore]; then
-    touch $test_root/.bidsignore
-    echo "*finalized.json" > $test_root/.bidsignore
+if [ -f "$test_root/.bidsignore" ]; then
+    echo "*finalized.json" > "$test_root/.bidsignore"
 else
-    echo "*finalized.json" >> $test_root/.bidsignore
+    echo "*finalized.json" >> "$test_root/.bidsignore"
 fi
 echo "*template.json" >> $test_root/.bidsignore
 

--- a/ui/src/components/niivue.vue
+++ b/ui/src/components/niivue.vue
@@ -12,16 +12,15 @@ import { mapState } from 'vuex';
 import { Niivue } from '@niivue/niivue';
 import axios from '../axios.instance';
 
-const nv = new Niivue({
-    dragAndDropEnabled: false,
-});
-
 export default defineComponent({
     props: ['path'],
     emits: ['close'],
     data() {
         return {
             open: false,
+            //per-component instance; el-dialog uses destroy-on-close so the prior
+            //canvas is removed each time, which would orphan a shared WebGL context
+            nv: null as any,
         };
     },
 
@@ -36,7 +35,12 @@ export default defineComponent({
     },
 
     mounted() {
+        this.nv = new Niivue({ dragAndDropEnabled: false });
         if (this.path) this.load();
+    },
+
+    beforeUnmount() {
+        if (this.nv) this.nv.closeAllVolumes();
     },
 
     methods: {
@@ -45,8 +49,8 @@ export default defineComponent({
                 const url = `${this.config.apihost}/download/${this.session._id}/${this.path}?token=${res.data}`;
                 this.open = true;
                 this.$nextTick(() => {
-                    nv.attachToCanvas(this.$refs.canvas);
-                    nv.loadVolumes([
+                    this.nv.attachToCanvas(this.$refs.canvas);
+                    this.nv.loadVolumes([
                         {
                             url: url,
                             volume: { hdr: null, img: null },
@@ -60,6 +64,7 @@ export default defineComponent({
         },
 
         close() {
+            if (this.nv) this.nv.closeAllVolumes();
             this.open = false;
             this.$emit('close');
         },

--- a/ui/src/libUnsafe.ts
+++ b/ui/src/libUnsafe.ts
@@ -678,17 +678,14 @@ export function setIntendedFor($root: IEzbids) {
                             }
                         }
 
-                        if (Object.keys(obj.IntendedFor).length !== 0) {
-                            obj.IntendedFor?.forEach((e) => {
+                        if (obj.IntendedFor.length !== 0) {
+                            obj.IntendedFor = obj.IntendedFor.filter((e: number) => {
                                 let IntendedForObj = $root.objects.filter((o: IObject) => o.idx === e)[0];
-                                if (IntendedForObj.exclude || IntendedForObj._exclude) {
-                                    let badIndexKey: number = obj.IntendedFor.indexOf(e);
-                                    delete obj.IntendedFor[badIndexKey];
-                                }
+                                return !(IntendedForObj.exclude || IntendedForObj._exclude);
                             });
                         }
                         if (obj._type.startsWith('fmap/')) {
-                            if (Object.keys(obj.IntendedFor).length === 0) {
+                            if (obj.IntendedFor.length === 0) {
                                 obj.validationWarnings = [
                                     'It is recommended that field map (fmap) sequences have IntendedFor set to at least 1 series ID. This is necessary if you plan on using processing BIDS-apps such as fMRIPrep',
                                 ];
@@ -698,7 +695,7 @@ export function setIntendedFor($root: IEzbids) {
                                 obj.validationWarnings = [];
                             }
                         } else if (obj._type === 'perf/m0scan') {
-                            if (Object.keys(obj.IntendedFor).length === 0) {
+                            if (obj.IntendedFor.length === 0) {
                                 obj.validationErrors = [
                                     'It is required that perfusion m0scan sequences have IntendedFor set to at least 1 series ID.',
                                 ];

--- a/ui/src/store/index.ts
+++ b/ui/src/store/index.ts
@@ -222,7 +222,6 @@ export interface ISession {
     create_date: string; //"2021-08-27T21:24:21.610Z"
     dicomCount: number; //2
     dicomDone: number; //2
-    request_headers: any; //{host: "dev1.soichi.us", x-real-ip: "45.16.200.251", x-forwarded-for: "45.16.200.251", x-forwarded-proto: "https", connection: "close", …}
     status: string; //"analyzed"
     status_msg: string; //"successfully run preprocess.sh"
 


### PR DESCRIPTION
## Summary

Eleven small, independent fixes uncovered during a code audit. Each is surgical and self-contained.

### Security
- **`/upload-multi` path traversal** — `destPath.startsWith(config.workdir)` accepted `paths: ["../<other-session>/..."]`, allowing an authenticated user to write into another session's workdir. Now validates against the session directory.
- **`request_headers` leak** — every `POST /session` persisted the full request headers (including `Authorization` / `Cookie`) to MongoDB, where they were returned by `GET /session/:id` and visible to anyone in the session's `allowedUsers` list. Capture and schema field removed.
- **`datasetDescription.Name` escape** — the user-supplied dataset name was concatenated directly into output paths in `convert.{ts,js}` and `bids.sh`. Now passed through `path.basename` with a leading-dot strip and a fallback.

### Correctness
- **Stale `finalize_finish_date` on rerun** — `handler.ts` cleared `finalize_end_date` and `deface_end_date`, neither of which exist on the schema (Mongoose silently dropped them). The Finalize page therefore rendered "All Done" with old downloads while a rerun was still in flight. Now clears the correct fields.
- **`IntendedFor` sparse-array** — cleanup used `delete arr[i]`, producing holes that `JSON.stringify` serialized as `null` and tripped bids-validator. Switched to `.filter()`; the surrounding `Object.keys(arr).length` checks were also wrong on sparse arrays and now use `.length`.
- **Niivue WebGL leak** — module-scoped singleton was reattached to a new canvas on every dialog open, orphaning prior WebGL contexts. Browsers cap concurrent contexts; previews stop rendering after enough opens. Now per-component, released on close.
- **`preprocess.sh` `.bidsignore` test** — `[ -f $test_root/.bidsignore]` (missing space) is a syntax error; the file-exists branch was dead and `.bidsignore` accumulated duplicates on re-runs.
- **`expand.sh` `.zst` loop** — used `$zip` instead of `$zst` and called `zst` instead of `zstd`.

## Test plan

Verified end-to-end against the docker-compose dev stack with `BRAINLIFE_AUTHENTICATION=false`:

- [x] `request_headers` absent from `GET /session/:id` response (sent a custom header, confirmed not echoed)
- [x] `/upload-multi` rejects `paths=../escaped/...` and `paths=../../tmp/leaked.txt` (HTTP 500 with `Error: invalid path: ...` in API log); legitimate `paths=subdir/foo.txt` still uploads to the correct location
- [x] `convert.js` with `Name="../../escaped"` writes to `bids/escaped` (basename only) — no escape; `Name=".."` falls back to `bids/dataset`; `Name="MyStudy"` unchanged
- [x] Seeded `finalize_finish_date: 2020-01-01`, called `/finalize`, watched handler clear it to `null` while transitioning to `bidsing`
- [x] API tsc-watch reports `Found 0 errors`; UI vite build produces a clean bundle
- [x] `bash -n` passes on both modified shell scripts; the `.bidsignore` `if`/`else` branches both fire as intended after the fix

`IntendedFor` and Niivue changes were not exercised through the browser (would need real fmap data and repeated dialog opens) but are unit-verified: filtered array serializes as `[1,3]` rather than `[1,null,3]`; vite bundle compiles.